### PR TITLE
Displayer Optimization

### DIFF
--- a/examples/display_image_bitmap/main.rs
+++ b/examples/display_image_bitmap/main.rs
@@ -1,10 +1,7 @@
 use std::fs::File;
 
 use sogl::{
-    display::{
-        BitmapBitsPerPixel, BitmapCompression, BitmapOptions, Canvas, CanvasCoordinate, Displayer,
-        ImageDisplayBuilder, ImageFormat,
-    },
+    display::{Canvas, CanvasCoordinate, Displayer, ImageDisplayBuilder, DEFAULT_IMAGE_FORMAT},
     model::Color,
 };
 
@@ -20,15 +17,10 @@ fn main() {
         let _ = subject.set_content(CanvasCoordinate::Linear(i), &Color::new(val, 0, 0, u8::MAX));
     }
 
-    let file = &mut File::create("out.bmp").unwrap();
+    let file = File::create("out.bmp").unwrap();
 
     let mut displayer = ImageDisplayBuilder::new()
-        .set_image_format(ImageFormat::Bitmap(BitmapOptions {
-            bits_per_pixel: BitmapBitsPerPixel::Rgb24Bit,
-            compression: BitmapCompression::BIRGB,
-            x_pixels_per_meter: u16::MAX as u32,
-            y_pixels_per_meter: u16::MAX as u32,
-        }))
+        .set_image_format(DEFAULT_IMAGE_FORMAT)
         .set_output(file)
         .build()
         .unwrap();

--- a/examples/display_image_bitmap/main.rs
+++ b/examples/display_image_bitmap/main.rs
@@ -14,7 +14,7 @@ fn main() {
 
     for i in 0..size.pow(2) {
         let val = (i % 256) as u8;
-        let _ = subject.set_content(CanvasCoordinate::Linear(i), &Color::new(val, 0, 0, u8::MAX));
+        let _ = subject.set_content(CanvasCoordinate::Linear(i), Color::new(val, 0, 0, u8::MAX));
     }
 
     let file = File::create("out.bmp").unwrap();
@@ -25,5 +25,5 @@ fn main() {
         .build()
         .unwrap();
 
-    displayer.show(&subject);
+    let _ = displayer.show(&subject);
 }

--- a/examples/display_text_file/main.rs
+++ b/examples/display_text_file/main.rs
@@ -14,7 +14,7 @@ fn main() {
         let val = (i * u8::MAX as usize / size) as u8;
         let _ = subject.set_content(
             CanvasCoordinate::Linear(i),
-            &Color::new(val, val, val, u8::MAX),
+            Color::new(val, val, val, u8::MAX),
         );
     }
 
@@ -25,5 +25,5 @@ fn main() {
         .build()
         .unwrap();
 
-    displayer.show(&subject);
+    let _ = displayer.show(&subject);
 }

--- a/examples/display_text_stdout/main.rs
+++ b/examples/display_text_stdout/main.rs
@@ -1,8 +1,6 @@
 extern crate sogl;
 
-use std::io;
-
-use sogl::display::{Canvas, CanvasCoordinate, Displayer, TextDisplayBuilder, DEFAULT_CHARSET};
+use sogl::display::{Canvas, CanvasCoordinate, Displayer, TextDisplayBuilder};
 use sogl::model::Color;
 
 fn main() {
@@ -10,23 +8,17 @@ fn main() {
 
     let mut subject = Canvas::new(size, size);
 
-    for j in 0..size {
-        for i in 0..size {
-            let val = (i * u8::MAX as usize / size) as u8;
-            let _ = subject.set_content(
-                CanvasCoordinate::Cartesian(j, i),
-                &Color::new(val, val, val, u8::MAX),
-            );
-        }
+    for i in 0..size.pow(2) {
+        let val = (i * u8::MAX as usize / size) as u8;
+        let _ = subject.set_content(
+            CanvasCoordinate::Linear(i),
+            Color::new(val, val, val, u8::MAX),
+        );
     }
 
-    let stream = io::stdout().lock();
-
-    let mut displayer = TextDisplayBuilder::new()
-        .set_charset(DEFAULT_CHARSET)
-        .set_output(stream)
+    let mut displayer = TextDisplayBuilder::default()
         .build()
         .unwrap();
 
-    displayer.show(&subject);
+    let _ = displayer.show(&subject);
 }

--- a/examples/display_text_stdout/main.rs
+++ b/examples/display_text_stdout/main.rs
@@ -20,7 +20,7 @@ fn main() {
         }
     }
 
-    let stream = &mut io::stdout().lock();
+    let stream = io::stdout().lock();
 
     let mut displayer = TextDisplayBuilder::new()
         .set_charset(DEFAULT_CHARSET)

--- a/src/display/canvas.rs
+++ b/src/display/canvas.rs
@@ -2,10 +2,7 @@ use std::{usize, vec};
 
 use crate::{error::Error, model::Color};
 
-pub const ERROR_COORDINATE_OUT_OF_RANGE: Error = Error {
-    message: "coordinate out of range",
-};
-
+#[derive(Debug)]
 pub enum CanvasCoordinate {
     Cartesian(usize, usize),
     Linear(usize),
@@ -38,19 +35,19 @@ impl Canvas {
         self.width * self.height
     }
 
-    pub fn set_content(&mut self, coord: CanvasCoordinate, color: &Color) -> Result<(), Error> {
+    pub fn set_content(&mut self, coord: CanvasCoordinate, color: Color) -> Result<(), Error> {
         match coord {
             CanvasCoordinate::Cartesian(x, y) => {
                 let idx = x * self.width + y;
                 if idx >= self.width * self.height {
-                    return Err(ERROR_COORDINATE_OUT_OF_RANGE);
+                    return Err(Error::OutOfBounds(coord));
                 }
                 self.content[idx] = color.clone();
                 Ok(())
             }
             CanvasCoordinate::Linear(i) => {
                 if i >= self.width * self.height {
-                    return Err(ERROR_COORDINATE_OUT_OF_RANGE);
+                    return Err(Error::OutOfBounds(coord));
                 }
                 self.content[i] = color.clone();
                 Ok(())
@@ -58,20 +55,20 @@ impl Canvas {
         }
     }
 
-    pub fn get_content(&self, coord: CanvasCoordinate) -> Option<Color> {
+    pub fn get_content(&self, coord: CanvasCoordinate) -> Result<Color, Error> {
         match coord {
             CanvasCoordinate::Cartesian(x, y) => {
                 let idx = x * self.width + y;
                 if idx >= self.width * self.height {
-                    return None;
+                    return Err(Error::OutOfBounds(coord));
                 }
-                Some(self.content[idx].clone())
+                Ok(self.content[idx].clone())
             }
             CanvasCoordinate::Linear(i) => {
                 if i >= self.width * self.height {
-                    return None;
+                    return Err(Error::OutOfBounds(coord));
                 }
-                Some(self.content[i].clone())
+                Ok(self.content[i].clone())
             }
         }
     }

--- a/src/display/displayer.rs
+++ b/src/display/displayer.rs
@@ -1,11 +1,7 @@
-use crate::error::Error;
+use crate::error::Result;
 
 pub use super::Canvas;
 
-pub const ERROR_OUTPUT_NOT_SET: Error = Error {
-    message: "output not set",
-};
-
 pub trait Displayer {
-    fn show(&mut self, c: &Canvas);
+    fn show(&mut self, c: &Canvas) -> Result<usize>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,27 @@
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Error {
-    pub message: &'static str,
+use std::fmt;
+use std::fmt::Display;
+use std::io;
+
+use crate::display::CanvasCoordinate;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    MissingParams(String),
+    OutOfBounds(CanvasCoordinate),
+    IoError(io::Error),
 }
 
-impl Error {
-    pub fn new(message: &'static str) -> Error {
-        Error { message }
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(value: io::Error) -> Self {
+        Self::IoError(value)
     }
 }

--- a/src/model/color.rs
+++ b/src/model/color.rs
@@ -32,7 +32,7 @@ impl Color {
         (self.value & 0x000000FF) as u8
     }
 
-    pub fn grayscale(&self) -> u8 {
+    pub fn intensity(&self) -> u8 {
         let temp: u16 = self.red() as u16 + self.green() as u16 + self.blue() as u16;
         (temp / 3) as u8
     }

--- a/src/model/color.rs
+++ b/src/model/color.rs
@@ -1,12 +1,6 @@
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Color {
     value: u32,
-}
-
-impl Default for Color {
-    fn default() -> Color {
-        Color { value: 0 }
-    }
 }
 
 impl Color {

--- a/tests/image_display.rs
+++ b/tests/image_display.rs
@@ -4,17 +4,19 @@ use std::io;
 
 use sogl::display::{
     BitmapBitsPerPixel, BitmapCompression, BitmapOptions, ImageDisplayBuilder, ImageFormat,
-    ERROR_IMAGE_FORMAT_NOT_SET, ERROR_OUTPUT_NOT_SET,
 };
 
 #[cfg(test)]
 mod image_displayer_builder_tests {
+
+    use sogl::error::Error;
+
     use super::*;
 
     #[test]
     fn test_build_image_displayer_no_image_format() {
-        let result = ImageDisplayBuilder::new().build();
-        assert!(matches!(result, Err(ERROR_IMAGE_FORMAT_NOT_SET)));
+        let result = ImageDisplayBuilder::new().build().unwrap_err();
+        assert!(matches!(result, Error::MissingParams(_)));
     }
 
     #[test]
@@ -26,9 +28,10 @@ mod image_displayer_builder_tests {
                 x_pixels_per_meter: i32::MAX as u32,
                 y_pixels_per_meter: i32::MAX as u32,
             }))
-            .build();
+            .build()
+            .unwrap_err();
 
-        assert!(matches!(result, Err(ERROR_OUTPUT_NOT_SET)));
+        assert!(matches!(result, Error::MissingParams(_)));
     }
 
     #[test]

--- a/tests/text_display.rs
+++ b/tests/text_display.rs
@@ -17,10 +17,10 @@ mod text_displayer_tests {
         let medium = Color::new(120, 120, 120, u8::MAX);
         let light = Color::new(u8::MAX, u8::MAX, u8::MAX, u8::MAX);
 
-        let mut stream = io::stdout();
+        let stream = io::stdout();
         let displayer = TextDisplayBuilder::new()
             .set_charset("123")
-            .set_output(&mut stream)
+            .set_output(stream)
             .build()
             .unwrap();
 
@@ -32,6 +32,8 @@ mod text_displayer_tests {
 
 #[cfg(test)]
 mod text_displayer_builder_tests {
+    use std::fs::{self, File};
+
     use super::*;
 
     #[test]
@@ -49,12 +51,30 @@ mod text_displayer_builder_tests {
     }
 
     #[test]
-    fn test_build_text_displayer_success() {
-        let mut stream = io::stdout();
+    fn test_build_default_text_displayer_success() {
+        let result = TextDisplayBuilder::default().build();
+        assert!(matches!(result, Ok(_)));
+    }
+
+    #[test]
+    fn test_build_stdout_text_displayer_success() {
+        let stream = io::stdout();
         let result = TextDisplayBuilder::new()
             .set_charset(&DEFAULT_CHARSET)
-            .set_output(&mut stream)
+            .set_output(stream)
             .build();
+
+        assert!(matches!(result, Ok(_)));
+    }
+
+    #[test]
+    fn test_build_file_text_displayer_success() {
+        let stream = File::create("test.txt").unwrap();
+        let result = TextDisplayBuilder::new()
+            .set_charset(&DEFAULT_CHARSET)
+            .set_output(stream)
+            .build();
+        let _ = fs::remove_file("test.txt");
 
         assert!(matches!(result, Ok(_)));
     }

--- a/tests/text_display.rs
+++ b/tests/text_display.rs
@@ -1,8 +1,6 @@
 extern crate sogl;
 
-use sogl::display::{
-    TextDisplayBuilder, DEFAULT_CHARSET, ERROR_CHARSET_NOT_SET, ERROR_OUTPUT_NOT_SET,
-};
+use sogl::display::{TextDisplayBuilder, DEFAULT_CHARSET};
 use std::io;
 
 #[cfg(test)]
@@ -34,20 +32,23 @@ mod text_displayer_tests {
 mod text_displayer_builder_tests {
     use std::fs::{self, File};
 
+    use sogl::error::Error;
+
     use super::*;
 
     #[test]
     fn test_build_text_displayer_no_charset() {
-        let result = TextDisplayBuilder::new().build();
-        assert!(matches!(result, Err(ERROR_CHARSET_NOT_SET)));
+        let result = TextDisplayBuilder::new().build().unwrap_err();
+        assert!(matches!(result, Error::MissingParams(_)));
     }
 
     #[test]
     fn test_build_text_displayer_no_output() {
         let result = TextDisplayBuilder::new()
             .set_charset(&DEFAULT_CHARSET)
-            .build();
-        assert!(matches!(result, Err(ERROR_OUTPUT_NOT_SET)));
+            .build()
+            .unwrap_err();
+        assert!(matches!(result, Error::MissingParams(_)));
     }
 
     #[test]


### PR DESCRIPTION
Replace trait object with generics on structs that implements the `Displayer` trait. This is done to improve performance by eliminating unnecessary dynamic dispatches. While at it, also cleaned up syntax a little bit.